### PR TITLE
Fix serialize implementation which affected ancestor/descendant commands

### DIFF
--- a/src/main/java/io/github/ashwith/flutter/FlutterElement.java
+++ b/src/main/java/io/github/ashwith/flutter/FlutterElement.java
@@ -51,6 +51,8 @@ public class FlutterElement extends RemoteWebElement {
                         tempMap.put(key, new JsonPrimitive(String.valueOf(value)));
                     } else if (value instanceof JsonElement) {
                         tempMap.put(key, value);
+                    } else if (value instanceof Map) {
+                        tempMap.put(key, gson.toJson(value));
                     } else {
                         tempMap.put(key, localInstance);
                     }

--- a/src/main/java/io/github/ashwith/flutter/FlutterElement.java
+++ b/src/main/java/io/github/ashwith/flutter/FlutterElement.java
@@ -43,7 +43,7 @@ public class FlutterElement extends RemoteWebElement {
      * @return Stringify map
      */
     private String serialize(final Map<String, Object> rawMap) {
-        final JsonPrimitive localInstance = new JsonPrimitive(false);
+        final JsonPrimitive localInstance = new JsonPrimitive(String.valueOf(false));
         Map<String, Object> tempMap = new HashMap<>();
         rawMap.forEach(
                 (key, value) -> {


### PR DESCRIPTION
Fixes #6 

Two fixes so that 

* The default bool value used in the serialize() method needs to be converted to a String otherwise you get errors when processing commands on the appium server since the server expects type String. Errors such as: 'Uncaught extension error while executing waitFor: type 'bool' is not a subtype of type 'Map<String, dynamic>' in type cast'
* When using finders ByAncestor and ByDescendant, the type for value is Map, so this case needs to be handled in the forEach for ancestor and descendant commands to work. Otherwise the results are returned as localInstance, which is not what is needed.